### PR TITLE
fix: Add missing Boost libs for UHD tools

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -86,3 +86,8 @@ parts:
       - iproute2
       - iputils-ping
       - net-tools
+      - libboost-program-options1.74.0
+      - libboost-chrono1.74.0
+      - libboost-filesystem1.74.0
+      - libboost-serialization1.74.0
+      - libboost-thread1.74.0


### PR DESCRIPTION
# Description

The UHD tools and library for using USRP radios are missing Boost libraries to be able to run. This PR adds them to the rock.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
